### PR TITLE
Update property name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ The default setting is `scijava`.
 To change this, set the `coding-style` property in your Maven POM. For example:
 ```
 <properties>
-    <coding-style>imglib2</coding-style>
+    <scijava.coding-style>imglib2</scijava.coding-style>
 </properties>
 ```


### PR DESCRIPTION
Looking at [`pom-scijava-base`](https://github.com/scijava/pom-scijava-base/blob/9150c24eff783d788758c255c0567054f15fa8bf/pom.xml#L743-L745), the correct property name should be `scijava.coding-sytle` instead of just `coding-style`.

(Nevertheless, I still have problems running `imglib2` style formatting, see #2.)
